### PR TITLE
Start the jenkins module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@ Command line tool for working with oVirt CI.
 ## Setup
 
 Visit https://jenkins.ovirt.org/user/username/configure
-and create API Token.
+and create an API Token.
 
-Keep the token in the configuration file at:
+Keep your Jenkins user id and API Token in the configuration file at:
 
-    $HOME/.config/oci.conf
+    ~/.config/oci.conf
 
 Here is an example configuration file:
 
-    [auth]
+    [jenkins]
+    user_id = johnd
     api_token = 3e8cd699a2564d9ba2855831bf4cb5eb
 
 

--- a/build-artifacts.py
+++ b/build-artifacts.py
@@ -1,0 +1,42 @@
+import logging
+import os
+import sys
+
+from six.moves import configparser
+
+from oci import gerrit
+from oci import jenkins
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-7s [%(name)s] %(message)s")
+
+log = logging.getLogger("build-artifacts")
+
+change = sys.argv[1]
+
+config = configparser.ConfigParser()
+conf_path =  os.path.expanduser("~/.config/oci.conf")
+config.read(conf_path)
+
+ga = gerrit.API(host=config.get("gerrit", "host"))
+
+ja = jenkins.API(
+    host=config.get("jenkins", "host"),
+    user_id=config.get("jenkins", "user_id"),
+    api_token=config.get("jenkins", "api_token"))
+
+log.info("[ 1/5 ] Getting build info for change %s", change)
+info = ga.build_info(change)
+
+log.info("[ 2/5 ] Starting build-artifacts job for %s", info)
+queue_url = ja.run(
+    url=info["url"], ref=info["ref"], stage="build-artifacts")
+
+log.info("[ 3/5 ] Waiting for queue item %s", queue_url)
+job_url = ja.wait_for_queue(queue_url)
+
+log.info("[ 4/5 ] Waiting for job %s", job_url)
+result = ja.wait_for_job(job_url)
+
+log.info("[ 5/5 ] Job completed with %s", result)

--- a/oci.conf.example
+++ b/oci.conf.example
@@ -1,0 +1,14 @@
+[gerrit]
+# Gerrit host (default gerrit.ovirt.org)
+host = gerrit.ovirt.org
+
+[jenkins]
+# Jenkins host (default jenkins.ovirt.org)
+host = jenkins.ovirt.org
+
+# Your Jenkins user id.
+user_id = johnd
+
+# Your Jeknins API Token generated here:
+# https://jenkins.ovirt.org/user/username/configure
+api_token = c30d2404b7be492ebbdc2f53045a6fb6

--- a/oci/jenkins.py
+++ b/oci/jenkins.py
@@ -1,0 +1,203 @@
+import base64
+import json
+import logging
+import time
+
+from contextlib import closing
+
+from six.moves import http_client
+from six.moves.urllib import parse as url_parse
+
+log = logging.getLogger("jenkins")
+
+
+class Error(Exception):
+    """ General Jeknins error """
+
+
+class Timeout(Error):
+    """ Timeout expired """
+
+
+class API(object):
+
+    def __init__(self, host, user_id, api_token):
+        self.host = host
+        self._user_id = user_id
+        self._api_token = api_token
+
+    def run(self, url=None, ref=None, stage=None):
+        """
+        Build stage with specified ref for the project identified by url.
+
+        Return a URL to the Jenkins queue item. The caller need to monitor this
+        URL to discover the acutal job URL.
+        """
+        params = {}
+        if url:
+            params["STD_CI_CLONE_URL"] = url
+        if ref:
+            params["STD_CI_REFSPEC"] = ref
+        if stage:
+            params["STD_CI_STAGE"] = stage
+
+        return self.build("standard-manual-runner", parameters=params)
+
+    def build(self, job_name, parameters=None):
+        """
+        Build job_name with optional parameters.
+
+        Return a URL to the Jenkins queue item. The caller need to monitor this
+        URL to discover the acutal job URL.
+        """
+        if parameters:
+            url = "/job/{}/buildWithParameters".format(job_name)
+            body = url_parse.urlencode(parameters)
+        else:
+            url = "/job/{}/build".format(job_name)
+            body = ""
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Authorization": "Basic {}".format(self._basic_credentials())
+        }
+
+        con = http_client.HTTPSConnection(self.host)
+        with closing(con):
+            log.debug("POST host=%s url=%s body=%r headers=%s",
+                      self.host, url, body, headers)
+            con.request("POST", url, body=body, headers=headers)
+
+            res = con.getresponse()
+            if res.status != http_client.CREATED:
+                raise Error(
+                    "Request failed host={} url={} reason={} body={!r}"
+                    .format(self.host, url, res.reason, res.read()))
+
+            log.debug("CREATED headers=%s", res.getheaders())
+            return res.getheader("location")
+
+    def wait_for_queue(self, url, interval=1, timeout=None):
+        """
+        Wait until queue item idenfied by url is executed.
+
+        I did not find documention for this, but watching the queue JSON API
+        during builds show the following steps:
+
+        1. Item is blocked.
+
+            {
+              "blocked": True.
+              "why": null
+            }
+
+        2. Waiting for available executor - this can take minutes for
+           system tests job.
+
+            {
+              "blocked": False
+              "why" : "Waiting for next available executor..."
+            }
+
+        3. Job is executing. We should continue to watch the job using the
+           executable url, since the queue item will removed after couple of
+           minutes.
+
+            {
+              "blocked": False,
+              "executable": {
+                "url": "http://jenkins.ovirt.org/job/name/4330/"
+              }
+              "why": null
+            }
+
+        Return the executing job URL.
+        """
+        url = url_parse.urlparse(url)
+        item_status = url.path + "/api/json?tree=executable[url],blocked,why"
+
+        def job_started(status):
+            return not status["blocked"] and "executable" in status
+
+        status = self._wait_for(
+            job_started,
+            url.netloc,
+            item_status,
+            interval=interval,
+            timeout=timeout)
+
+        return status["executable"]["url"]
+
+    def wait_for_job(self, url, interval=10, timeout=None):
+        """
+        Wait until job idenfied by url is finished.
+
+        Return "SUCCESS" if job was successful, otherwise "FAILURE".
+        """
+        url = url_parse.urlparse(url)
+        job_status = url.path + "/api/json?tree=building,result"
+
+        def job_completed(status):
+            return not status["building"]
+
+        status = self._wait_for(
+            job_completed,
+            url.netloc,
+            job_status,
+            interval=interval,
+            timeout=timeout)
+
+        return status["result"]
+
+    def _wait_for(self, cond, host, url, interval, timeout=None):
+        """
+        Preform a JSON API GET request with url, and check returned JSON with
+        the provided cond function. If cond returns True, return the parsed
+        JSON to the caller.
+
+        cond is a function accepting status dict and returning True or False.
+
+        Repeat the check every interval seconds, until cond returns True of
+        timeout expires.
+
+        Return status dict returned by Jenkins.
+        """
+        if timeout:
+            deadline = time.time() + timeout
+
+        con = http_client.HTTPSConnection(host)
+        with closing(con):
+            while True:
+                time.sleep(interval)
+
+                log.debug("GET host=%s url=%s", host, url)
+                con.request("GET", url)
+
+                res = con.getresponse()
+                body = res.read()
+                if res.status != http_client.OK:
+                    raise Error(
+                        "Request failed host={} url={} reason={} body={!r}"
+                        .format(host, url, res.reason, body))
+
+                log.debug("OK headers=%s body=%r", res.getheaders(), body)
+                status = json.loads(body)
+                if cond(status):
+                    return status
+
+                if timeout and time.time() > deadline:
+                    raise Timeout(
+                        "Timeout waiting for host={} url={}".format(host, url))
+
+    def _basic_credentials(self):
+        """
+        Return HTTP Basic Authentication credentials string.
+        See https://tools.ietf.org/html/rfc2617
+
+        To allow unicode user_id and password, we must encode the credentials
+        using UTF-8. This encoding is not specified by the RFC, but it is the
+        only encoding that can work for unicode. Because UTF-8 is compatible
+        with US-ASCII, non-unicode values are passed correctly.
+        """
+        credentials = "{}:{}".format(self._user_id, self._api_token)
+        return base64.b64encode(credentials.encode("utf-8")).decode("ascii")

--- a/system-tests.py
+++ b/system-tests.py
@@ -1,0 +1,71 @@
+import logging
+import os
+import sys
+
+from six.moves import configparser
+
+from oci import gerrit
+from oci import jenkins
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-7s [%(name)s] %(message)s")
+
+log = logging.getLogger("system-tests")
+
+change = sys.argv[1]
+
+if len(sys.argv) > 2:
+    engine_version = sys.argv[2]
+else:
+    engine_version = "master"
+
+suite_type = "basic"
+
+config = configparser.ConfigParser()
+conf_path =  os.path.expanduser("~/.config/oci.conf")
+config.read(conf_path)
+
+ga = gerrit.API(host=config.get("gerrit", "host"))
+
+ja = jenkins.API(
+    host=config.get("jenkins", "host"),
+    user_id=config.get("jenkins", "user_id"),
+    api_token=config.get("jenkins", "api_token"))
+
+log.info("[ 1/8 ] Getting build info for change %s", change)
+info = ga.build_info(change)
+
+log.info("[ 2/8 ] Starting build-artifacts job for %s", info)
+queue_url = ja.run(
+    url=info["url"], ref=info["ref"], stage="build-artifacts")
+
+log.info("[ 3/8 ] Waiting for queue item %s", queue_url)
+job_url = ja.wait_for_queue(queue_url)
+
+log.info("[ 4/8 ] Waiting for job %s", job_url)
+result = ja.wait_for_job(job_url)
+
+if result != "SUCCESS":
+    log.error("Build artifacts %s failed", job_url)
+    sys.exit(1)
+
+log.info("[ 5/8 ] Starting oVirt system tests %s suite with custom "
+         "repos %s",
+         suite_type, job_url)
+queue_url = ja.build(
+    "ovirt-system-tests_manual",
+    parameters={
+        "CUSTOM_REPOS": job_url,
+        "ENGINE_VERSION": engine_version,
+        "SUITE_TYPE": suite_type,
+    }
+)
+
+log.info("[ 6/8 ] Waiting for queue item %s", queue_url)
+job_url = ja.wait_for_queue(queue_url)
+
+log.info("[ 7/8 ] Waiting for job %s", job_url)
+result = ja.wait_for_job(job_url)
+
+log.info("[ 8/8 ] System tests completed with %s", result)

--- a/test.md
+++ b/test.md
@@ -87,16 +87,25 @@ Response:
 
 Request:
 
-    $ curl -g -i https://jenkins.ovirt.org/queue/item/370116/api/json?pretty=true'&tree=executable[url],blocked'
+    $ curl -g -i https://jenkins.ovirt.org/queue/item/370116/api/json?pretty=true'&tree=executable[url],blocked,why'
 
 Response:
 
     {
       "_class" : "hudson.model.Queue$LeftItem",
       "blocked" : true,
+      "why": null
     }
 
 The task is blocked in the queue. We need to try again later.
+
+    {
+      "_class" : "hudson.model.Queue$LeftItem",
+      "blocked" : false,
+      "why" : "Waiting for next available executor on ‘integ-tests’"
+    }
+
+The task is waiting for available executor. We need to try again later.
 
     {
       "_class" : "hudson.model.Queue$LeftItem",
@@ -105,6 +114,7 @@ The task is blocked in the queue. We need to try again later.
         "_class" : "org.jenkinsci.plugins.workflow.job.WorkflowRun",
         "url" : "http://jenkins.ovirt.org/job/standard-manual-runner/77/"
       }
+      "why": null
     }
 
 The task is building.


### PR DESCRIPTION
Add jenkins module implementing:
- run() - run any stage for any project using the "standard-manual-runner" job.
- build() - build any job with parameters.
- wait_for_queue() - wait for job queued by build()
- wait_for_job() - wait until job started with build() finish

Testing the jenkins module automatically is complicated. For now I added
a build-artifacts.py script that can be used to test the build-artifacts
flow.

Here is an example run log:

    $ python build-artifacts.py 98535
    2019-03-15 18:38:35,939 INFO    [build-artifacts] [ 1/5 ] Getting build info for change 98535
    2019-03-15 18:38:36,632 INFO    [build-artifacts] [ 2/5 ] Starting build-artifacts job for {'url': u'git://gerrit.ovirt.org/vdsm', 'ref': u'refs/changes/35/98535/3'}
    2019-03-15 18:38:37,515 INFO    [build-artifacts] [ 3/5 ] Waiting for queue item https://jenkins.ovirt.org/queue/item/382669/
    2019-03-15 18:38:39,372 INFO    [build-artifacts] [ 4/5 ] Waiting for job http://jenkins.ovirt.org/job/standard-manual-runner/87/
    2019-03-15 18:56:01,792 INFO    [build-artifacts] [ 5/5 ] Job completed with SUCCESS

The build-artifacts requires a configuration file at ~/.config/oci.conf.
See oci.conf.example for the details.

@Funkabell, @EdDev, @rollandf, would like to review?