### PR TITLE
Add config parsing module

### DIFF
--- a/oci/config.py
+++ b/oci/config.py
@@ -6,7 +6,7 @@ DEFAULT_CONFIG = {
     ('jenkins', 'host', 'jenkins.ovirt.org'),
     ('gerrit', 'host', 'gerrit.ovirt.org')}
 
-Jenkins = namedtuple('jenkins', 'host, user_name, api_token')
+Jenkins = namedtuple('jenkins', 'host, user_id, api_token')
 Gerrit = namedtuple('gerrit', 'host')
 Config = namedtuple('config', 'jenkins, gerrit')
 
@@ -29,18 +29,17 @@ def config_parser():
 def load(path=os.path.expanduser("~/.config/oci.conf")):
     cfg = config_parser()
 
-    with open(path, 'r') as config_file:
-        cfg.readfp(config_file)
-        try:
-            return Config(
-                jenkins=Jenkins(
-                    host=cfg.get('jenkins', 'host'),
-                    user_name=cfg.get('jenkins', 'user_id'),
-                    api_token=cfg.get('jenkins', 'api_token')),
-                gerrit=Gerrit(
-                    host=cfg.get('gerrit', 'host')
-                ))
-        except configparser.NoOptionError as err:
-            raise Error(
-                "No option '%s' in section '%s' in OCI config file."
-                % (err.option, err.section))
+    cfg.read(path)
+    try:
+        return Config(
+            jenkins=Jenkins(
+                host=cfg.get('jenkins', 'host'),
+                user_id=cfg.get('jenkins', 'user_id'),
+                api_token=cfg.get('jenkins', 'api_token')),
+            gerrit=Gerrit(
+                host=cfg.get('gerrit', 'host')
+            ))
+    except configparser.NoOptionError as err:
+        raise Error(
+            "Option {!r} in section {!r} is required"
+            .format(err.option, err.section))

--- a/oci/config.py
+++ b/oci/config.py
@@ -1,0 +1,46 @@
+from collections import namedtuple
+import ConfigParser
+import os
+
+gerrit_default_host = 'gerrit.ovirt.org'
+jenkins_default_host = 'jenkins.ovirt.org'
+
+
+def load():
+    config_dir = os.path.join(os.path.expanduser('~'), '.config/oci.conf')
+    config = ConfigParser.RawConfigParser(allow_no_value=True)
+
+    with open(config_dir, 'r') as config_file:
+        config.readfp(config_file)
+
+        # set default Jenkins host if not present
+        jenkins_host = jenkins_default_host
+        if config.has_option('jenkins', 'host'):
+            jenkins_host = config.get('jenkins', 'host')
+
+        # set default Gerrit host if not present
+        gerrit_host = jenkins_default_host
+        if config.has_option('gerrit', 'host'):
+            gerrit_host = config.get('gerrit', 'host')
+
+        try:
+            token = config.get('jenkins', 'api_token')
+            user = config.get('jenkins', 'user_id')
+        except ConfigParser.NoOptionError as e:
+            raise Exception(
+                'A setting in the config file is missing: ', e)
+
+    Jenkins = namedtuple('jenkins', 'host, user_name, api_token')
+    Gerrit = namedtuple('gerrit', 'host')
+    Config = namedtuple('config', 'jenkins, gerrit')
+
+    result = Config(
+        jenkins=Jenkins(
+            host=jenkins_host,
+            user_name=user,
+            api_token=token),
+        gerrit=Gerrit(
+            host=gerrit_host
+        ))
+
+    return result

--- a/oci/config.py
+++ b/oci/config.py
@@ -1,46 +1,46 @@
 from collections import namedtuple
-import ConfigParser
 import os
+from six.moves import configparser
 
-gerrit_default_host = 'gerrit.ovirt.org'
-jenkins_default_host = 'jenkins.ovirt.org'
+DEFAULT_CONFIG = {
+    ('jenkins', 'host', 'jenkins.ovirt.org'),
+    ('gerrit', 'host', 'gerrit.ovirt.org')}
+
+Jenkins = namedtuple('jenkins', 'host, user_name, api_token')
+Gerrit = namedtuple('gerrit', 'host')
+Config = namedtuple('config', 'jenkins, gerrit')
 
 
-def load():
-    config_dir = os.path.join(os.path.expanduser('~'), '.config/oci.conf')
-    config = ConfigParser.RawConfigParser(allow_no_value=True)
+class Error(Exception):
+    pass
 
-    with open(config_dir, 'r') as config_file:
-        config.readfp(config_file)
 
-        # set default Jenkins host if not present
-        jenkins_host = jenkins_default_host
-        if config.has_option('jenkins', 'host'):
-            jenkins_host = config.get('jenkins', 'host')
+def config_parser():
+    cfg = configparser.RawConfigParser()
 
-        # set default Gerrit host if not present
-        gerrit_host = jenkins_default_host
-        if config.has_option('gerrit', 'host'):
-            gerrit_host = config.get('gerrit', 'host')
+    # Setup default configuration
+    for (section, key, value) in DEFAULT_CONFIG:
+        cfg.add_section(section)
+        cfg.set(section, key, value)
 
+    return cfg
+
+
+def load(path=os.path.expanduser("~/.config/oci.conf")):
+    cfg = config_parser()
+
+    with open(path, 'r') as config_file:
+        cfg.readfp(config_file)
         try:
-            token = config.get('jenkins', 'api_token')
-            user = config.get('jenkins', 'user_id')
-        except ConfigParser.NoOptionError as e:
-            raise Exception(
-                'A setting in the config file is missing: ', e)
-
-    Jenkins = namedtuple('jenkins', 'host, user_name, api_token')
-    Gerrit = namedtuple('gerrit', 'host')
-    Config = namedtuple('config', 'jenkins, gerrit')
-
-    result = Config(
-        jenkins=Jenkins(
-            host=jenkins_host,
-            user_name=user,
-            api_token=token),
-        gerrit=Gerrit(
-            host=gerrit_host
-        ))
-
-    return result
+            return Config(
+                jenkins=Jenkins(
+                    host=cfg.get('jenkins', 'host'),
+                    user_name=cfg.get('jenkins', 'user_id'),
+                    api_token=cfg.get('jenkins', 'api_token')),
+                gerrit=Gerrit(
+                    host=cfg.get('gerrit', 'host')
+                ))
+        except configparser.NoOptionError as err:
+            raise Error(
+                "No option '%s' in section '%s' in OCI config file."
+                % (err.option, err.section))

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -1,0 +1,53 @@
+from contextlib import contextmanager
+import pytest
+
+from oci.oci import config
+
+
+@contextmanager
+def write_config_file(tmpdir, cfg_data):
+    cfg_file = tmpdir.join("oci.conf")
+    cfg_file.write(cfg_data)
+    try:
+        yield cfg_file
+    finally:
+        pass
+
+
+def test_load_minimal(tmpdir):
+    cfg_data = """[jenkins]
+user_id = fred
+api_token = 12345
+"""
+    with write_config_file(tmpdir, cfg_data) as cfg_file:
+        cfg = config.load(str(cfg_file))
+
+    assert cfg.jenkins.user_name == 'fred'
+    assert cfg.jenkins.api_token == '12345'
+    assert cfg.jenkins.host == 'jenkins.ovirt.org'
+    assert cfg.gerrit.host == 'gerrit.ovirt.org'
+
+
+def test_missing_required_options(tmpdir):
+    cfg_data = """[jenkins]
+user_id = fred
+"""
+    with write_config_file(tmpdir, cfg_data) as cfg_file:
+        with pytest.raises(config.Error) as err:
+            config.load(str(cfg_file))
+            assert err == config.Error
+
+
+def test_load_custom_config_that_has_(tmpdir):
+    cfg_data = """[jenkins]
+user_id = fred
+api_token = 12345
+host = dummy.jenkins.org
+[gerrit]
+host = dummy.gerrit.org
+"""
+    with write_config_file(tmpdir, cfg_data) as cfg_file:
+        cfg = config.load(str(cfg_file))
+
+    assert cfg.jenkins.host == 'dummy.jenkins.org'
+    assert cfg.gerrit.host == 'dummy.gerrit.org'

--- a/test/gerrit_test.py
+++ b/test/gerrit_test.py
@@ -1,5 +1,4 @@
-from oci import gerrit
-
+from oci.oci import gerrit
 
 def test_build_info():
     ga = gerrit.API("gerrit.ovirt.org")

--- a/test/gerrit_test.py
+++ b/test/gerrit_test.py
@@ -1,4 +1,4 @@
-from oci.oci import gerrit
+from oci import gerrit
 
 def test_build_info():
     ga = gerrit.API("gerrit.ovirt.org")


### PR DESCRIPTION
Add config parsing module implementing:
load() - returns a namedtuple with all the config values in
tuple form.

Available config values as for now:
config:
- jenkins:
  - host
  - user_id
  - api_token
- gerrit:
  - gerrit_host

Example:
```
>>> config.jenkins.host
jenkins.ovirt.org
```

Resolves #2
Resolves #5