### PR TITLE
Add a stable source for gerrit tests

### DIFF
--- a/test/gerrit_test.py
+++ b/test/gerrit_test.py
@@ -3,9 +3,9 @@ from oci import gerrit
 
 def test_build_info():
     ga = gerrit.API("gerrit.ovirt.org")
-    res = ga.build_info("96774")
+    res = ga.build_info("98719")
 
     assert res == {
-        "ref": "refs/changes/74/96774/7",
+        "ref": "refs/changes/19/98719/2",
         "url": "git://gerrit.ovirt.org/vdsm",
     }


### PR DESCRIPTION
Patch https://gerrit.ovirt.org/#/c/98719/ was merged thus no
changes will be made to the tested values.

resolves #20 