### PR TITLE
Add the config module functionality to tests

### DIFF
--- a/build-artifacts.py
+++ b/build-artifacts.py
@@ -1,9 +1,7 @@
 import logging
-import os
 import sys
 
-from six.moves import configparser
-
+from oci import config
 from oci import gerrit
 from oci import jenkins
 
@@ -15,16 +13,14 @@ log = logging.getLogger("build-artifacts")
 
 change = sys.argv[1]
 
-config = configparser.ConfigParser()
-conf_path =  os.path.expanduser("~/.config/oci.conf")
-config.read(conf_path)
+cfg = config.load("~/.config/oci.conf")
 
-ga = gerrit.API(host=config.get("gerrit", "host"))
+ga = gerrit.API(host=cfg.gerrit.host)
 
 ja = jenkins.API(
-    host=config.get("jenkins", "host"),
-    user_id=config.get("jenkins", "user_id"),
-    api_token=config.get("jenkins", "api_token"))
+    host=cfg.jenkins.host,
+    user_id=cfg.jenkins.user_id,
+    api_token=cfg.jenkins.api_token)
 
 log.info("[ 1/5 ] Getting build info for change %s", change)
 info = ga.build_info(change)

--- a/build-artifacts.py
+++ b/build-artifacts.py
@@ -13,7 +13,7 @@ log = logging.getLogger("build-artifacts")
 
 change = sys.argv[1]
 
-cfg = config.load("~/.config/oci.conf")
+cfg = config.load()
 
 ga = gerrit.API(host=cfg.gerrit.host)
 

--- a/system-tests.py
+++ b/system-tests.py
@@ -1,9 +1,7 @@
 import logging
-import os
 import sys
 
-from six.moves import configparser
-
+from oci import config
 from oci import gerrit
 from oci import jenkins
 
@@ -22,16 +20,14 @@ else:
 
 suite_type = "basic"
 
-config = configparser.ConfigParser()
-conf_path =  os.path.expanduser("~/.config/oci.conf")
-config.read(conf_path)
+cfg = config.load("~/.config/oci.conf")
 
-ga = gerrit.API(host=config.get("gerrit", "host"))
+ga = gerrit.API(host=cfg.gerrit.host)
 
 ja = jenkins.API(
-    host=config.get("jenkins", "host"),
-    user_id=config.get("jenkins", "user_id"),
-    api_token=config.get("jenkins", "api_token"))
+    host=cfg.jenkins.host,
+    user_id=cfg.jenkins.user_id,
+    api_token=cfg.jenkins.api_token)
 
 log.info("[ 1/8 ] Getting build info for change %s", change)
 info = ga.build_info(change)


### PR DESCRIPTION
After adding a module to parse config files (#16), adding this
functionality to build-artifacts and system-tests test runs.

Resolves #18