### PR TITLE
Support oci daemonized execution

### DIFF
--- a/oci/jenkins.py
+++ b/oci/jenkins.py
@@ -46,6 +46,36 @@ class API(object):
 
         return self.build("standard-manual-runner", parameters=params)
 
+    def system_tests(self, custom_repos=None, engine_version="master",
+                     suite_type="basic"):
+        """
+        Run oVirt system tests manual job.
+
+        Arguments:
+            custom_repos (str): build-artifacts job URL for project used in
+                oVirt system tests, or yum repo URL (rec:https://...) with the
+                pakcages that should be used in this run.
+            engine_version (str): Engine version to use for this run. For available
+                versions see ENGINE_VERSION popup menu at:
+                https://jenkins.ovirt.org/job/ovirt-system-tests_manual/build
+            suite_type (str): Suite type to run. For available suite types see
+                SUITE_TYPE popup menu at:
+                https://jenkins.ovirt.org/job/ovirt-system-tests_manual/build
+
+        Return a URL to the Jenkins queue item. The caller need to monitor this
+        URL to discover the acutal job URL.
+        """
+        params = {}
+        if custom_repos:
+            # TODO: Support multiple repos.
+            params["CUSTOM_REPOS"] = custom_repos
+        if engine_version:
+            params["ENGINE_VERSION"] = engine_version
+        if suite_type:
+            params["SUITE_TYPE"] = suite_type
+
+        return self.build("ovirt-system-tests_manual", parameters=params)
+
     @network.retry()
     def build(self, job_name, parameters=None):
         """

--- a/oci/main.py
+++ b/oci/main.py
@@ -93,14 +93,10 @@ def system_tests(args):
 
     out.step("Starting oVirt system tests job")
     out.info(("suite", suite_type), ("repo", job_url))
-    queue_url = ja.build(
-        "ovirt-system-tests_manual",
-        parameters={
-            "CUSTOM_REPOS": job_url,
-            "ENGINE_VERSION": args.engine_version,
-            "SUITE_TYPE": suite_type,
-        }
-    )
+    queue_url = ja.system_tests(
+        custom_repos=job_url,
+        engine_version=args.engine_version,
+        suite_type=suite_type)
 
     out.step("Waiting until job is executed")
     out.info(("queue", queue_url))


### PR DESCRIPTION
Add arg flag --daemon: 
ovirt-ci will execute in background and output will be redirected
to a log file named /var/tmp/oci_{command}_{change id}.log