### PR TITLE
contrib: add bash auto-completion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Here is an example configuration file:
 
 Full example is available at: [ovirt-ci.conf.example](ovirt-ci.conf.example)
 
+Optionally, you can setup bash auto-completetion for ovirt-ci tool.
+Make sure you have installed package `bash-completion`.
+Copy `ovirt-ci/contrib/ovirt-ci` to `/usr/share/bash-completion/completions/`
+and once you start new bash, you can use `<tab>` to auto-complete ovirt-ci commands.
 
 ## Usage
 

--- a/contrib/ovirt-ci
+++ b/contrib/ovirt-ci
@@ -1,0 +1,23 @@
+# ovirt-ci completion                             -*- shell-script -*-
+
+_ovirt-ci()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    case $prev in
+	'-h'|'--help')
+	    return
+	    ;;
+    esac
+    
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "--help --debug" -- "$cur") )
+    else
+        COMPREPLY=( $(compgen -W "build-artifacts system-tests run" -- "$cur") )
+    fi
+
+} &&
+complete -F _ovirt-ci ovirt-ci
+
+# ex: filetype=sh


### PR DESCRIPTION
Add bash auto-completion script into `contrib` directory
and corresponding readme how to set it up.